### PR TITLE
Update default styles to match iOS range slider; make slider line optional

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "description": "An Angular range slider with accessibility",
   "main": "index.js",
   "scripts": {
+    "build": "./node_modules/.bin/grunt",
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "repository": {

--- a/src/scss/slider.scss
+++ b/src/scss/slider.scss
@@ -8,6 +8,7 @@ $ch-slider-handle-color: blue !default;
 $ch-slider-handle-radius: 9999px !default;
 $ch-slider-fill-color: green !default;
 
+$ch-slider-line: true !default;
 $ch-slider-line-width: 2px !default;
 $ch-slider-line-height: 23px !default;
 $ch-slider-line-color: $ch-slider-fill-color !default;
@@ -45,15 +46,17 @@ $ch-slider-line-color: $ch-slider-fill-color !default;
             border-top-left-radius: $ch-slider-handle-radius;
             border-bottom-left-radius: $ch-slider-handle-radius;
         }
-        
-        .ch-slider-line {
-            position: absolute;
-            top: calc(0px - #{$ch-slider-line-height / 2} + #{$ch-slider-bar-height / 2});
-            bottom: 0;
-            height: $ch-slider-line-height;
-            width: $ch-slider-line-width;
-            background-color: $ch-slider-line-color;
-            left: calc(50% - #{$ch-slider-line-width  / 2});
+
+        @if $ch-slider-line {
+            .ch-slider-line {
+                position: absolute;
+                top: calc(0px - #{$ch-slider-line-height / 2} + #{$ch-slider-bar-height / 2});
+                bottom: 0;
+                height: $ch-slider-line-height;
+                width: $ch-slider-line-width;
+                background-color: $ch-slider-line-color;
+                left: calc(50% - #{$ch-slider-line-width  / 2});
+            }
         }
     }
 

--- a/src/scss/slider.scss
+++ b/src/scss/slider.scss
@@ -1,12 +1,13 @@
-$ch-slider-bar-height: 10px !default;
-$ch-slider-bar-radius: 10px !default;
-$ch-slider-bar-color: grey !default;
+$ch-slider-bar-height: 4px !default;
+$ch-slider-bar-radius: 4px !default;
+$ch-slider-bar-color: #ccc !default;
 
 $ch-slider-handle-height: 20px !default;
 $ch-slider-handle-width: 20px !default;
-$ch-slider-handle-color: blue !default;
+$ch-slider-handle-color: #fff !default;
+$ch-slider-handle-shadow: 0 0 2px rgba(0, 0, 0, 0.5), 1px 3px 5px rgba(0, 0, 0, 0.25) !default;
 $ch-slider-handle-radius: 9999px !default;
-$ch-slider-fill-color: green !default;
+$ch-slider-fill-color: #4d8aeb !default;
 
 $ch-slider-line: true !default;
 $ch-slider-line-width: 2px !default;
@@ -29,6 +30,7 @@ $ch-slider-line-color: $ch-slider-fill-color !default;
             height: $ch-slider-handle-height;
             background-color: $ch-slider-handle-color;
             border-radius: $ch-slider-handle-radius;
+            box-shadow: $ch-slider-handle-shadow;
             display: block;
             position: absolute;
             top: -(($ch-slider-handle-height - $ch-slider-bar-height) / 2);


### PR DESCRIPTION
This includes the following changes:

- NPM `build` script to run Grunt. Makes contributing easier since you don't have to globally install `grunt-cli`
- Slider line is optional and can be disabled by setting the `$ch-slider-line` variable to `false`
- Default styles now match closer the iOS range slider. These can be overridden exactly as before but make the demo a little nicer and serve as a drop-in theme.
- To remove the shadow in a custom theme just change `$ch-slider-handle-shadow` to `none`