### PR TITLE
Disable keys when slider element is disabled

### DIFF
--- a/src/js/slider.js
+++ b/src/js/slider.js
@@ -147,6 +147,9 @@
                 };
 
                 function handleKeys(event) {
+                    if($scope.disabled) {
+                        return;
+                    }
                     switch (event.keyCode) {
                         case Keys.UP:
                         case Keys.RIGHT:


### PR DESCRIPTION
Mouse-events are disabled whenever the `<slider>` element is disabled using the `disable`-attribute, but still allows the user to use keys to change value.

This change also disables keys.