### PR TITLE
Style disabled slider differently and allow overrides

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,10 @@ $ch-slider-handle-color: blue;
 $ch-slider-handle-radius: 9999px;
 
 $ch-slider-fill-color: green;
+$ch-slider-disabled-color: grey;
+$ch-slider-disabled-fill-color: black;
 ```
+
 ### CSS
 If you don't want to use the SCSS file you can instead include the css file in your HTML
 ```html

--- a/examples/index.html
+++ b/examples/index.html
@@ -34,11 +34,14 @@
         <label>Step
             <input ng-init="sliderStep = 2" ng-model="sliderStep">
         </label>
+
+        <hr />
+        <h2>Disabled slider</h2>
+        <slider ng-init="sliderValue = 125" model="sliderValue" step="{{ sliderStep }}" min="{{ sliderMin }}" max="{{ sliderMax }}" disabled>
+        </slider>
     </div>
     <script>
         angular.module('ch.examples.slider', ['chasselberg.slider']);
     </script>
-
 </body>
-
 </html>

--- a/src/scss/slider.scss
+++ b/src/scss/slider.scss
@@ -8,7 +8,8 @@ $ch-slider-handle-color: #fff !default;
 $ch-slider-handle-shadow: 0 0 2px rgba(0, 0, 0, 0.5), 1px 3px 5px rgba(0, 0, 0, 0.25) !default;
 $ch-slider-handle-radius: 9999px !default;
 $ch-slider-fill-color: #4d8aeb !default;
-
+$ch-slider-disabled-color: #ccc !default;
+$ch-slider-disabled-fill-color: #000 !default;
 $ch-slider-line: true !default;
 $ch-slider-line-width: 2px !default;
 $ch-slider-line-height: 23px !default;
@@ -61,8 +62,17 @@ $ch-slider-line-color: $ch-slider-fill-color !default;
             }
         }
     }
-
-    &[disabled] .ch-slider .ch-slider-bar .ch-slider-handle {
-        background-color: black;
+}
+slider  {
+    &[disabled] {
+        .ch-slider-bar {
+            background-color: $ch-slider-disabled-color;
+            .ch-slider-handle {
+                background-color: $ch-slider-disabled-color;
+            }
+            .ch-slider-fill {
+                background-color: $ch-slider-disabled-fill-color;
+            }
+        }
     }
 }


### PR DESCRIPTION
The previous styling for a disabled slider element was wrong, the disabled attribute is set on the `<slider>` element.

This change style it differently, and allow any using application to override both fill and background color. Also updated the example to include a disabled slider for look-and-feel.